### PR TITLE
[PS-213] Add npmrc file for private GH packages

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -14,3 +14,9 @@ echo $APP_NAME > $ENV_DIR/HOST_NAME
 echo https://$APP_NAME.herokuapp.com > $ENV_DIR/HOST_ASSETS_BASE
 HOST_ASSETS_BASE_VAR=`cat $ENV_DIR/HOST_ASSETS_BASE`
 topic "HOST_ASSETS_BASE is ${HOST_ASSETS_BASE_VAR}"
+
+# Create ~/.npmrc file
+topic "Generating ~/.npmrc file"
+echo "@offerzen:registry=https://npm.pkg.github.com" > ~/.npmrc
+echo "//npm.pkg.github.com/:_authToken=$NPM_AUTH_TOKEN" >> ~/.npmrc
+topic "Created ~/.npmrc file"


### PR DESCRIPTION
## Context
When using private NPM packages hosted on GitHub Package Manager, we need to authenticate with a token. This `~/.npmrc` file should allow further build steps to complete.