### PR TITLE
[PS-213] Print actual text into npmrc file

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -17,6 +17,6 @@ topic "HOST_ASSETS_BASE is ${HOST_ASSETS_BASE_VAR}"
 
 # Create ~/.npmrc file
 topic "Generating ~/.npmrc file"
-echo "@offerzen:registry=https://npm.pkg.github.com" > ~/.npmrc
-echo "//npm.pkg.github.com/:_authToken=$NPM_AUTH_TOKEN" >> ~/.npmrc
+echo '@offerzen:registry=https://npm.pkg.github.com' > ~/.npmrc
+echo '//npm.pkg.github.com/:_authToken=$NPM_AUTH_TOKEN' >> ~/.npmrc
 topic "Created ~/.npmrc file"


### PR DESCRIPTION
## Context
It seem that the env var isn't available during this step, so we echo out the actual text and have the subsequent step resolve it.